### PR TITLE
Fix failed downloads when proxy is used

### DIFF
--- a/src/disbox-file-manager.js
+++ b/src/disbox-file-manager.js
@@ -90,7 +90,7 @@ class DiscordFileStorage {
         if (extensionResult !== null) {
             return await (await fetch(extensionResult)).blob();
         }
-        return await (await this.fetchfUrlFromProxy(url)).blob();
+        return await (await this.fetchUrlFromProxy(url)).blob();
     }
 
     async download(messageIds, writeStream, onProgress = null, fileSize=-1) {


### PR DESCRIPTION
Fixes a typo in `fetchUrl()` that caused `fetchUrlFromProxy()` to never be called, and an error to be raised.

UI Alert:
![Error Alert](https://user-images.githubusercontent.com/64789500/160266185-e17bcdc9-24b4-4d73-9540-537e89681b23.png)

Stack Trace:
```
disbox-file-manager.js:93 Uncaught (in promise) TypeError: this.fetchfUrlFromProxy is not a function
    at e.<anonymous> (disbox-file-manager.js:93:34)
    at c (runtime.js:63:40)
    at Generator._invoke (runtime.js:294:22)
    at Generator.next (runtime.js:119:21)
    at ma (asyncToGenerator.js:3:20)
    at i (asyncToGenerator.js:25:9)
```