### PR TITLE
502 error handling

### DIFF
--- a/src/disbox-file-manager.js
+++ b/src/disbox-file-manager.js
@@ -97,8 +97,11 @@ class DiscordWebhookClient {
             this.rateLimitWaits[type] = (retryAfter) * 1000;
             console.log("Rate limit exceeded, retrying");
             return await this.fetchFromApi(path, {method, body, type});
-        }
-        if (status >= 400) {
+        } else if (status === 502) {
+            this.rateLimitWaits[type] = 10 * 1000;
+            console.log("Gateway unavailable, retrying");
+            return await this.fetchFromApi(path, {method, body, type});
+        } else if (status >= 400) {
             throw new Error(`Failed to ${type} with status ${status}: ${await response.text()}`);
         }
         return response;


### PR DESCRIPTION
The Discord API can sometimes return status code 502. According to their docs, you just have to "wait a bit and retry" your request (https://discord.com/developers/docs/topics/opcodes-and-status-codes).

This can be problematic when there isn't proper error handling because file uploads can be interrupted and will never complete. Waiting an arbitrary amount of time (like 10 seconds) and then retrying the request should fix this.
![disbox502](https://github.com/DisboxApp/web/assets/45981228/e02061e7-9c4b-48c3-a422-bd397bf3f392)

Additionally,  if one or more requests return status code 429, line 102 (`throw new Error(...);`) will ALWAYS run after all recursive calls to `this.fetchFromApi` finish. This means that errors will populate the console even if the upload succeeded with rate limits. I'm not sure if this is intentional, but I changed the conditional to an `else if` block just in case. Changes are welcomed